### PR TITLE
SCRUM-170-TEST-CASES-Create-Ticket-Form-Page-in-Staff-Dashboard

### DIFF
--- a/nova_project/.gitignore
+++ b/nova_project/.gitignore
@@ -14,6 +14,10 @@
 /coverage
 *.test.*
 *.spec.*
+!src/**/*.test.ts
+!src/**/*.test.tsx
+!src/**/*.spec.ts
+!src/**/*.spec.tsx
 
 # next.js
 /.next/

--- a/nova_project/package.json
+++ b/nova_project/package.json
@@ -16,9 +16,9 @@
     "health": "curl -s http://localhost:3000/api/health",
     "lh:local": "powershell -NoProfile -Command \"New-Item -ItemType Directory -Path 'docs/lighthouse' -Force | Out-Null\";npx lighthouse http://localhost:3000 --preset=desktop --output=html --output-path=./docs/lighthouse/local-desktop.html",
     "lh:preview": "powershell -NoProfile -Command \"New-Item -ItemType Directory -Path 'docs/lighthouse' -Force | Out-Null\"; npx lighthouse https://nova-project-umber.vercel.app --preset=desktop --only-categories=performance,accessibility,best-practices,seo --output=html --output-path=./docs/lighthouse/preview-desktop.html",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:ui": "vitest --ui"
+    "test": "vitest run --config vitest.config.mjs",
+    "test:watch": "vitest --config vitest.config.mjs",
+    "test:ui": "vitest --config vitest.config.mjs --ui"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.932.0",

--- a/nova_project/src/app/api/tickets/staff/route.test.ts
+++ b/nova_project/src/app/api/tickets/staff/route.test.ts
@@ -1,0 +1,259 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, txMock } = vi.hoisted(() => {
+  const tx = {
+    ticket: { create: vi.fn() },
+    ticketLine: { createMany: vi.fn() },
+    catalogItem: { updateMany: vi.fn() },
+  };
+
+  return {
+    txMock: tx,
+    mockPrisma: {
+      account: { findUnique: vi.fn() },
+      catalogItem: { findMany: vi.fn() },
+      $transaction: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  prisma: mockPrisma,
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/tickets/staff", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("tickets staff API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockPrisma.$transaction.mockImplementation(async (cb: typeof Function) =>
+      cb(txMock),
+    );
+  });
+
+  // Verifies malformed JSON bodies are rejected before request parsing.
+  it("returns 400 for invalid JSON body", async () => {
+    const request = new NextRequest("http://localhost/api/tickets/staff", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{invalid",
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toMatchObject({
+      success: false,
+      error: "Invalid JSON body.",
+    });
+  });
+
+  // Verifies ticket type validation blocks unsupported values.
+  it("returns 400 for invalid ticket type", async () => {
+    const response = await POST(
+      makeRequest({
+        type: "BAD_TYPE",
+        note: "test",
+        createdByEmail: "staff@example.com",
+        lines: [{ catalogItemId: 1, countDelta: 1 }],
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Ticket type is invalid.");
+  });
+
+  // Verifies duplicate catalog items across lines are rejected.
+  it("returns 400 for duplicate catalog item lines", async () => {
+    const response = await POST(
+      makeRequest({
+        type: "ORDER",
+        note: "test",
+        createdByEmail: "staff@example.com",
+        lines: [
+          { catalogItemId: 1, countDelta: 1 },
+          { catalogItemId: 1, countDelta: 2 },
+        ],
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Duplicate catalog items are not allowed.");
+  });
+
+  // Verifies creator account must exist, be active, and not soft-deleted.
+  it("returns 400 when creator account is invalid", async () => {
+    mockPrisma.account.findUnique.mockResolvedValue(null);
+
+    const response = await POST(
+      makeRequest({
+        type: "ORDER",
+        note: "valid note",
+        createdByEmail: "missing@example.com",
+        lines: [{ catalogItemId: 1, countDelta: 1 }],
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe(
+      "Unable to resolve a valid active account for ticket creator.",
+    );
+  });
+
+  // Verifies only STAFF/ADMIN roles can create tickets.
+  it("returns 403 for non-staff creator role", async () => {
+    mockPrisma.account.findUnique.mockResolvedValue({
+      id: 10,
+      role: "USER",
+      status: "ACTIVE",
+      deletedAt: null,
+    });
+
+    const response = await POST(
+      makeRequest({
+        type: "ORDER",
+        note: "valid note",
+        createdByEmail: "user@example.com",
+        lines: [{ catalogItemId: 1, countDelta: 1 }],
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Only staff accounts can create tickets.");
+  });
+
+  // Verifies all referenced catalog item IDs must exist.
+  it("returns 400 when a catalog item does not exist", async () => {
+    mockPrisma.account.findUnique.mockResolvedValue({
+      id: 10,
+      role: "STAFF",
+      status: "ACTIVE",
+      deletedAt: null,
+    });
+    mockPrisma.catalogItem.findMany.mockResolvedValue([]);
+
+    const response = await POST(
+      makeRequest({
+        type: "ORDER",
+        note: "valid note",
+        createdByEmail: "staff@example.com",
+        lines: [{ catalogItemId: 99, countDelta: 1 }],
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Catalog item 99 does not exist.");
+  });
+
+  // Verifies ORDER/SPOILAGE requests are blocked when requested quantity exceeds stock.
+  it("returns 400 when ORDER quantity exceeds stock", async () => {
+    mockPrisma.account.findUnique.mockResolvedValue({
+      id: 10,
+      role: "STAFF",
+      status: "ACTIVE",
+      deletedAt: null,
+    });
+    mockPrisma.catalogItem.findMany.mockResolvedValue([
+      { id: 1, itemName: "Slides", quantityInStock: 2 },
+    ]);
+
+    const response = await POST(
+      makeRequest({
+        type: "ORDER",
+        note: "valid note",
+        createdByEmail: "staff@example.com",
+        lines: [{ catalogItemId: 1, countDelta: 5 }],
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe(
+      '"Slides" only has 2 in stock, but 5 was requested.',
+    );
+  });
+
+  // Verifies successful SUPPLY creation writes positive deltas and returns ticket metadata.
+  it("creates SUPPLY ticket successfully", async () => {
+    mockPrisma.account.findUnique.mockResolvedValue({
+      id: 10,
+      role: "STAFF",
+      status: "ACTIVE",
+      deletedAt: null,
+    });
+    mockPrisma.catalogItem.findMany.mockResolvedValue([
+      { id: 1, itemName: "Slides", quantityInStock: 2 },
+    ]);
+    txMock.ticket.create.mockResolvedValue({ id: 123 });
+    txMock.ticketLine.createMany.mockResolvedValue({ count: 1 });
+    txMock.catalogItem.updateMany.mockResolvedValue({ count: 1 });
+
+    const response = await POST(
+      makeRequest({
+        type: "SUPPLY",
+        note: "restock",
+        createdByEmail: "staff@example.com",
+        lines: [{ catalogItemId: 1, countDelta: 3 }],
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      data: {
+        ticketId: 123,
+        lineCount: 1,
+      },
+    });
+    expect(txMock.ticketLine.createMany).toHaveBeenCalledWith({
+      data: [{ ticketId: 123, catalogItemId: 1, countDelta: 3 }],
+    });
+  });
+
+  // Verifies transactional stock failures map to user-facing insufficient-stock errors.
+  it("returns 400 when stock changes fail during transaction", async () => {
+    mockPrisma.account.findUnique.mockResolvedValue({
+      id: 10,
+      role: "STAFF",
+      status: "ACTIVE",
+      deletedAt: null,
+    });
+    mockPrisma.catalogItem.findMany.mockResolvedValue([
+      { id: 1, itemName: "Slides", quantityInStock: 100 },
+    ]);
+    txMock.ticket.create.mockResolvedValue({ id: 111 });
+    txMock.ticketLine.createMany.mockResolvedValue({ count: 1 });
+    txMock.catalogItem.updateMany.mockResolvedValue({ count: 0 });
+
+    const response = await POST(
+      makeRequest({
+        type: "ORDER",
+        note: "consume stock",
+        createdByEmail: "staff@example.com",
+        lines: [{ catalogItemId: 1, countDelta: 4 }],
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe(
+      '"Slides" does not have enough stock to apply this ticket.',
+    );
+  });
+});

--- a/nova_project/src/app/staff/adminTaskView/page.tsx
+++ b/nova_project/src/app/staff/adminTaskView/page.tsx
@@ -349,9 +349,7 @@ function TaskCard({
             <div className="staffTaskRow">
               <span className="staffTaskLabel">Completed At:</span>
               <span className="staffTaskValue">
-                {task.isCompleted
-                  ? task.completedAt
-                  : "—"}
+                {task.isCompleted ? task.completedAt : "—"}
               </span>
             </div>
 
@@ -403,7 +401,7 @@ export default function StaffTaskViewPage() {
         acc[task.employeeName].push(task);
         return acc;
       },
-      {}
+      {},
     );
 
     return Object.entries(grouped);
@@ -434,7 +432,7 @@ export default function StaffTaskViewPage() {
   function toggleEmployeeCollapse(taskIds: number[]) {
     setCollapsedTaskIds((currentIds) => {
       const areAllEmployeeTasksCollapsed = taskIds.every((taskId) =>
-        currentIds.includes(taskId)
+        currentIds.includes(taskId),
       );
 
       if (areAllEmployeeTasksCollapsed) {
@@ -481,7 +479,10 @@ export default function StaffTaskViewPage() {
         <div className="staffCard col4">
           <div className="staffCardLabel">Late</div>
           <div className="staffCardValue staffTaskSummaryValue">
-            {mockTasks.filter((task) => task.currentStatus === "expired").length}
+            {
+              mockTasks.filter((task) => task.currentStatus === "expired")
+                .length
+            }
           </div>
           <div className="staffCardHint">Tasks past deadline.</div>
         </div>
@@ -530,7 +531,7 @@ export default function StaffTaskViewPage() {
         {groupedTasks.map(([employeeName, tasks]) => {
           const employeeTaskIds = tasks.map((task) => task.id);
           const areEmployeeTasksCollapsed = employeeTaskIds.every((taskId) =>
-            collapsedTaskIds.includes(taskId)
+            collapsedTaskIds.includes(taskId),
           );
 
           return (

--- a/nova_project/src/app/staff/dashboard/SidebarNav.tsx
+++ b/nova_project/src/app/staff/dashboard/SidebarNav.tsx
@@ -58,7 +58,9 @@ export default function SidebarNav() {
 
       <Section
         title="Tasks"
-        items={[{ label: "Employee Task Monitor", href: "/staff/adminTaskView" }]}
+        items={[
+          { label: "Employee Task Monitor", href: "/staff/adminTaskView" },
+        ]}
       />
 
       <Section

--- a/nova_project/src/app/staff/ticket_create/page.test.ts
+++ b/nova_project/src/app/staff/ticket_create/page.test.ts
@@ -1,0 +1,152 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import StaffTicketCreatePage from "./page";
+
+vi.mock("../../LoginStatusContext", () => ({
+  useLoginStatus: () => ({
+    accountEmail: "staff@example.com",
+  }),
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("staff ticket create page", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Verifies submit validation blocks ticket creation when the first line has no selected item.
+  it("shows validation error when submitting with empty first line", async () => {
+    const user = userEvent.setup();
+    render(React.createElement(StaffTicketCreatePage));
+
+    await user.click(screen.getByRole("button", { name: "Create Ticket" }));
+
+    expect(
+      await screen.findByText(
+        "First ticket line is missing a selected catalog item.",
+      ),
+    ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // Verifies value calculation blocks when an extra blank line exists.
+  it("shows validation error for empty additional line during value calculation", async () => {
+    const user = userEvent.setup();
+    render(React.createElement(StaffTicketCreatePage));
+
+    await user.click(screen.getByRole("button", { name: "Add ticket entry" }));
+    await user.click(screen.getByRole("button", { name: "Calculate Value" }));
+
+    expect(
+      await screen.findByText(
+        "Remove empty ticket lines before calculating value.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  // Verifies successful end-to-end create flow after selecting a catalog suggestion.
+  it("creates a ticket successfully after confirmation", async () => {
+    fetchMock.mockImplementation((input: string | URL | Request) => {
+      const url = String(input);
+
+      if (url.includes("/api/catalog/staff?")) {
+        return Promise.resolve(
+          jsonResponse({
+            success: true,
+            data: [
+              {
+                id: 1,
+                sku: "ABC-123",
+                itemName: "Prepared Slides",
+                category1: "Microscopy",
+                price: 12.5,
+                quantityInStock: 20,
+              },
+            ],
+          }),
+        );
+      }
+
+      if (url.endsWith("/api/tickets/staff")) {
+        return Promise.resolve(
+          jsonResponse({
+            success: true,
+            data: { ticketId: 42, lineCount: 1 },
+          }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unhandled fetch URL: ${url}`));
+    });
+
+    render(React.createElement(StaffTicketCreatePage));
+    const user = userEvent.setup();
+
+    await user.type(
+      screen.getByPlaceholderText("Search by SKU or Name"),
+      "slides",
+    );
+
+    const suggestionText = await screen.findByText("Prepared Slides");
+    const suggestionButton = suggestionText.closest("button");
+    expect(suggestionButton).not.toBeNull();
+    await user.click(suggestionButton as HTMLButtonElement);
+    await user.type(screen.getByPlaceholderText("Enter quantity"), "2");
+    await user.type(
+      screen.getByPlaceholderText("Add context for approvers/reviewers."),
+      "Need this for lab section.",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Create Ticket" }));
+    expect(
+      await screen.findByRole("dialog", { name: "Confirm Create Ticket" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Confirm Create" }));
+
+    expect(
+      await screen.findByText(
+        "Ticket created successfully. New ticket ID: 42.",
+      ),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/tickets/staff",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
+  // Verifies unsaved edits trigger confirmation before draft clearing.
+  it("opens clear confirmation when unsaved changes exist", async () => {
+    render(React.createElement(StaffTicketCreatePage));
+    const user = userEvent.setup();
+
+    await user.type(
+      screen.getByPlaceholderText("Add context for approvers/reviewers."),
+      "temporary note",
+    );
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(
+      await screen.findByRole("dialog", { name: "Confirm Clear Changes" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/nova_project/src/app/style.css
+++ b/nova_project/src/app/style.css
@@ -3691,7 +3691,9 @@ body:has(.loginPage) main {
   padding: 14px 20px;
   cursor: pointer;
   box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.12);
-  transition: transform 0.15s ease, opacity 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    opacity 0.15s ease;
 }
 
 .staffActionButton:hover {
@@ -4051,7 +4053,9 @@ body:has(.loginPage) main {
   padding: 12px 18px;
   cursor: pointer;
   box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.12);
-  transition: transform 0.15s ease, opacity 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    opacity 0.15s ease;
   white-space: nowrap;
 }
 

--- a/nova_project/vitest.config.mjs
+++ b/nova_project/vitest.config.mjs
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest/setup.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
Implemented test cases for the ticket creation form in the staff dashboard. Ran by running command: npx vitest run --reporter=verbose src/app/api/tickets/staff/route.test.ts src/app/staff/ticket_create/page.test.ts